### PR TITLE
Notes on visualizing curricula

### DIFF
--- a/docs/src/install.md
+++ b/docs/src/install.md
@@ -42,7 +42,9 @@ This final command, `using Gurobi`, should be run every time you restart Julia. 
 ```julia-repl
   julia> using CurricularAnalytics, Gurobi
 ```
+
 ### CurricularVisualization
+
 If you are planning to locally visualize the curricula made with this package you must install the [CurricularVisualization](https://github.com/CurricularAnalytics/CurricularVisualization.jl) package. To install it, enter Pkg mode from within Julia by hitting the `]` key, and then type:
 ```julia-repl
   pkg> add CurricularVisualization
@@ -51,6 +53,8 @@ This will install the pacakge, along with the other Julia packages needed to run
 ```julia-repl
   julia> using CurricularVisualization
 ```
+Note that just like the main toolbox, this package must be loaded again using `using CurricularVisualization` every time you restart Julia.
+
 ## Windows Specific Steps
 If you are using Windows you must add the location of Julia to your PATH environment variable. To do this go to Control Panel -> System -> Advanced System Settings -> Environment Variables -> Path and click edit. Here you must append the file path of the Julia \bin directory.
 

--- a/docs/src/install.md
+++ b/docs/src/install.md
@@ -42,7 +42,15 @@ This final command, `using Gurobi`, should be run every time you restart Julia. 
 ```julia-repl
   julia> using CurricularAnalytics, Gurobi
 ```
-
+### CurricularVisualization
+If you are planning to locally visualize the curricula made with this package you must install the [CurricularVisualization](https://github.com/CurricularAnalytics/CurricularVisualization.jl) package. To install it, enter Pkg mode from within Julia by hitting the `]` key, and then type:
+```julia-repl
+  pkg> add CurricularVisualization
+```
+This will install the pacakge, along with the other Julia packages needed to run it. To load and use the toolbox, hit the `backspace` key to return to the Julia REPL. Now type:
+```julia-repl
+  julia> using CurricularVisualization
+```
 ## Windows Specific Steps
 If you are using Windows you must add the location of Julia to your PATH environment variable. To do this go to Control Panel -> System -> Advanced System Settings -> Environment Variables -> Path and click edit. Here you must append the file path of the Julia \bin directory.
 

--- a/docs/src/install.md
+++ b/docs/src/install.md
@@ -32,7 +32,7 @@ After installing the Gurobi Solver you must run the following command in Pkg mod
 ```julia-repl
   pkg> add Gurobi
 ```
-Back in the normal Julia REPL, which can be returned to from Pkg mode by hitting `backspace`, you must know run the following:
+Back in the normal Julia REPL, which can be returned to from Pkg mode by hitting `backspace`, you must now run the following:
 ```julia-repl
   julia> using Gurobi
 ```

--- a/docs/src/visualize.md
+++ b/docs/src/visualize.md
@@ -1,6 +1,6 @@
 # Visualizing Curricula and Degree Plans
 
-In order to visualize curricula and degree plans, you must first install [Blink.jl](http://junolab.org/Blink.jl/latest/). For instructions on how to do this, see the [Installation](@ref) section.
+In order to visualize curricula and degree plans, you must first install [Blink.jl](http://junolab.org/Blink.jl/latest/) and [CurricularVisualization](https://github.com/CurricularAnalytics/CurricularVisualization.jl). For instructions on how to do this, see the [Installation](@ref) section.
 
 ## Visualization Functions
 


### PR DESCRIPTION
I just added a few notes to the documentation noting that to visualize curricula locally, users must install CurricularVisualization. 
Should help fix #131 .
Note that I did not remove the docstring on visualize, and as such that is still empty (since there is no visualize function in CurricularAnalytics and I don't know how to cross-reference another repo's docstring).